### PR TITLE
Improve loading states

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,9 @@ import "./globals.css";
 import { TailwindIndicator } from "../components/TailwindIndicator";
 import { ThemeProvider } from "../components/ThemeProvider";
 import SiteHeader from "../components/SiteHeader";
+import SessionCheck from "../components/SessionCheck";
+import LoadingHome from "./loading";
+import { Suspense } from "react";
 import { Metadata } from "next";
 import { siteConfig } from "../constants/siteConfig";
 import { GoogleAnalytics } from "@next/third-parties/google";
@@ -158,11 +161,15 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <div className="relative flex min-h-screen flex-col bg-background">
-            <SiteHeader />
-            <main className="flex-1 flex">{children}</main>
-            <TailwindIndicator />
-          </div>
+          <Suspense fallback={<LoadingHome />}>
+            <SessionCheck>
+              <div className="relative flex min-h-screen flex-col bg-background">
+                <SiteHeader />
+                <main className="flex-1 flex">{children}</main>
+                <TailwindIndicator />
+              </div>
+            </SessionCheck>
+          </Suspense>
         </ThemeProvider>
         <Analytics />
         <SpeedInsights />

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function LoadingHome() {
+  return (
+    <div className="mx-auto grow flex w-full">
+      <div className="flex flex-col items-center w-full space-y-4 mx-[2rem]">
+        <Skeleton className="h-[120px] w-[200px]" />
+        <Skeleton className="h-12 w-full md:w-[40rem]" />
+        <Skeleton className="h-5 w-full md:w-[400px]" />
+        <Skeleton className="h-6 w-48" />
+        <div className="grid grid-cols-1 md:grid-cols-2 w-full gap-4 md:w-[400px]">
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <Skeleton key={idx} className="h-10 w-full" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/login/_component/LoginForm.tsx
+++ b/app/login/_component/LoginForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 import { login } from "../actions";
 
 const loginFormSchema = z.object({
@@ -38,7 +39,7 @@ export default function LoginForm() {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 relative">
         <FormField
           control={form.control}
           name="email"
@@ -72,8 +73,16 @@ export default function LoginForm() {
           className="w-full"
           disabled={form.formState.isSubmitting}
         >
+          {form.formState.isSubmitting && (
+            <Loader2 className="animate-spin mr-2 h-4 w-4" />
+          )}
           로그인
         </Button>
+        {form.formState.isSubmitting && (
+          <div className="absolute inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center rounded">
+            <Loader2 className="animate-spin" width={32} height={32} />
+          </div>
+        )}
       </form>
     </Form>
   );

--- a/components/SessionCheck.tsx
+++ b/components/SessionCheck.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from "react";
+import { createClient } from "@/utils/supabase/server";
+
+export default async function SessionCheck({ children }: { children: ReactNode }) {
+  const supabase = createClient();
+  await supabase.auth.getSession();
+  return <>{children}</>;
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
 import MainNav from "./MainNav";
 import { MobileNav } from "./MobileNav";
 import { ModeToggle } from "./ModeToggle";
@@ -12,7 +13,7 @@ export default function SiteHeader() {
         <MobileNav />
         <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">
           <div className="w-full flex-1 md:w-auto md:flex-none">
-            <Suspense fallback={<></>}>
+            <Suspense fallback={<Skeleton className="h-9 w-full md:w-[20rem]" />}>
               <SiteHeaderCommandMenu />
             </Suspense>
           </div>


### PR DESCRIPTION
## Summary
- show a spinner during login attempts
- load the app layout through a session guard and show a fallback while checking the session

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407641eb10832cbc6fd8b09e7d720c